### PR TITLE
유저 이메일 검색 페이지 추가

### DIFF
--- a/apps/snutt-admin-web/src/app/App.svelte
+++ b/apps/snutt-admin-web/src/app/App.svelte
@@ -13,13 +13,14 @@
   import Link from './design-system/Link.svelte';
   import ConfigDetailPage from './pages/ConfigDetailPage/index.svelte';
   import ConfigPage from './pages/ConfigPage/index.svelte';
+  import DailyClassTypePage from './pages/DailyClassTypePage/index.svelte';
+  import DiaryPage from './pages/DiaryPage/index.svelte';
   import HomePage from './pages/HomePage/index.svelte';
   import LoginPage from './pages/LoginPage/index.svelte';
   import NotFoundPage from './pages/NotFoundPage/index.svelte';
   import PopupPage from './pages/PopupPage/index.svelte';
-  import DiaryPage from './pages/DiaryPage/index.svelte';
-  import DailyClassTypePage from './pages/DailyClassTypePage/index.svelte';
   import PushNotificationPage from './pages/PushNotificationPage/index.svelte';
+  import UserSearchPage from './pages/UserSearchPage/index.svelte';
 
   const queryClient = new QueryClient();
   const { authService } = getServiceContext();
@@ -48,6 +49,7 @@
           <Link class={'menuItem'} href="/popup">팝업</Link>
           <Link class={'menuItem'} href="/diary">강의일기장 질문</Link>
           <Link class={'menuItem'} href="/daily-class-type">Daily Class Type</Link>
+          <Link class={'menuItem'} href="/user-search">유저 검색</Link>
         </nav>
         <main>
           <Route path="/"><HomePage /></Route>
@@ -59,6 +61,7 @@
           <Route path="/popup"><PopupPage {token} /></Route>
           <Route path="/diary"><DiaryPage {token} /></Route>
           <Route path="/daily-class-type"><DailyClassTypePage {token} /></Route>
+          <Route path="/user-search"><UserSearchPage {token} /></Route>
           <Route path="*"><NotFoundPage /></Route>
         </main>
       </div>

--- a/apps/snutt-admin-web/src/app/contexts/ServiceContext.ts
+++ b/apps/snutt-admin-web/src/app/contexts/ServiceContext.ts
@@ -2,10 +2,11 @@ import { getContext } from 'svelte';
 
 import type { AuthService } from '../../services/AuthService';
 import type { ConfigService } from '../../services/ConfigService';
+import type { DiaryService } from '../../services/DiaryService';
 import type { PopupService } from '../../services/PopupService';
 import type { PushNotificationService } from '../../services/PushNotificationService';
 import type { ScreenService } from '../../services/ScreenService';
-import type { DiaryService } from '../../services/DiaryService';
+import type { UserService } from '../../services/UserService';
 
 const key = 'service';
 type ServiceContext = {
@@ -15,6 +16,7 @@ type ServiceContext = {
   screenService: ScreenService;
   popupService: PopupService;
   diaryService: DiaryService;
+  userService: UserService;
 };
 export const serviceContextSetter = (context: ServiceContext) => [key, context] as const;
 export const getServiceContext = () => getContext(key) as ServiceContext;

--- a/apps/snutt-admin-web/src/app/pages/DailyClassTypePage/CreateDailyClassTypePopup/index.svelte
+++ b/apps/snutt-admin-web/src/app/pages/DailyClassTypePage/CreateDailyClassTypePopup/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createQuery, useQueryClient } from '@tanstack/svelte-query';
+  import { useQueryClient } from '@tanstack/svelte-query';
 
   import { type Token } from '../../../../entities/Auth';
   import { getServiceContext } from '../../../contexts/ServiceContext';

--- a/apps/snutt-admin-web/src/app/pages/DailyClassTypePage/index.svelte
+++ b/apps/snutt-admin-web/src/app/pages/DailyClassTypePage/index.svelte
@@ -2,13 +2,13 @@
   import { createQuery, useQueryClient } from '@tanstack/svelte-query';
 
   import type { Token } from '../../../entities/Auth';
+  import ConfirmRequiredButton from '../../components/ConfirmRequiredButton.svelte';
   import { getServiceContext } from '../../contexts/ServiceContext';
   import Button from '../../design-system/Button.svelte';
   import Paper from '../../design-system/Paper.svelte';
   import Typography from '../../design-system/Typography.svelte';
   // import type { DailyClassType } from '../../../entities/Diary';
   import CreateDailyClassTypePopup from './CreateDailyClassTypePopup/index.svelte';
-  import ConfirmRequiredButton from '../../components/ConfirmRequiredButton.svelte';
 
   export let token: Token;
 
@@ -22,7 +22,7 @@
     queryFn: () =>
       diaryService
         .getDailyClassTypes(token)
-        .then((dailyClassTypes) => dailyClassTypes.sort((first, _) => (first.active === false ? 1 : -1))),
+        .then((dailyClassTypes) => dailyClassTypes.sort((first) => (first.active === false ? 1 : -1))),
   });
 
   const onClickDelete = async (name: string) => {

--- a/apps/snutt-admin-web/src/app/pages/DiaryPage/CreateQuestionPopup/index.svelte
+++ b/apps/snutt-admin-web/src/app/pages/DiaryPage/CreateQuestionPopup/index.svelte
@@ -4,9 +4,9 @@
   import { type Token } from '../../../../entities/Auth';
   import { getServiceContext } from '../../../contexts/ServiceContext';
   import Button from '../../../design-system/Button.svelte';
+  import Checkbox from '../../../design-system/Checkbox.svelte';
   import Input from '../../../design-system/Input.svelte';
   import Textarea from '../../../design-system/Textarea.svelte';
-  import Checkbox from '../../../design-system/Checkbox.svelte';
   import Typography from '../../../design-system/Typography.svelte';
 
   export let token: Token;
@@ -39,8 +39,8 @@
           answers: answers.split('\n').map((answer) => answer.trim()),
           shortAnswers: shortAnswers.split('\n').map((answer) => answer.trim()),
           targetDailyClassTypes: Object.entries(targetDailyClassTypes)
-            .filter(([_, value]) => value)
-            .map(([key, _]) => key),
+            .filter(([, value]) => value)
+            .map(([key]) => key),
           active: true,
         },
         token,

--- a/apps/snutt-admin-web/src/app/pages/DiaryPage/index.svelte
+++ b/apps/snutt-admin-web/src/app/pages/DiaryPage/index.svelte
@@ -2,11 +2,11 @@
   import { createQuery } from '@tanstack/svelte-query';
 
   import type { Token } from '../../../entities/Auth';
+  import type { DailyClassType } from '../../../entities/Diary';
   import { getServiceContext } from '../../contexts/ServiceContext';
   import Button from '../../design-system/Button.svelte';
   import Paper from '../../design-system/Paper.svelte';
   import Typography from '../../design-system/Typography.svelte';
-  import type { DailyClassType } from '../../../entities/Diary';
   import CreateQuestionPopup from './CreateQuestionPopup/index.svelte';
 
   export let token: Token;

--- a/apps/snutt-admin-web/src/app/pages/UserSearchPage/index.svelte
+++ b/apps/snutt-admin-web/src/app/pages/UserSearchPage/index.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { createMutation } from '@tanstack/svelte-query';
+
+  import type { Token } from '../../../entities/Auth';
+  import { AUTH_PROVIDER_LABEL } from '../../../entities/User';
+  import { getServiceContext } from '../../contexts/ServiceContext';
+  import Button from '../../design-system/Button.svelte';
+  import Input from '../../design-system/Input.svelte';
+  import Paper from '../../design-system/Paper.svelte';
+  import Typography from '../../design-system/Typography.svelte';
+
+  export let token: Token;
+
+  const { userService } = getServiceContext();
+
+  let email = '';
+
+  const mutation = createMutation({
+    mutationFn: (req: { email: string }) => userService.searchUsersByEmail({ email: req.email, token }),
+  });
+
+  $: isValid = email.trim().length > 0 && !$mutation.isPending;
+
+  const onSubmit = () => isValid && $mutation.mutate({ email });
+
+  const formatDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  };
+</script>
+
+<div class="wrapper">
+  <header class="header">
+    <Typography variant="subtitle">유저 검색</Typography>
+  </header>
+
+  <form on:submit|preventDefault={onSubmit}>
+    <div class="search-row">
+      <Input required label="이메일" bind:value={email} placeholder="example@snu.ac.kr" />
+      <Button type="submit" disabled={!isValid}>검색</Button>
+    </div>
+  </form>
+
+  <section class="results">
+    {#if $mutation.isPending}
+      <Typography variant="body">검색 중...</Typography>
+    {:else if $mutation.isError}
+      <Typography variant="body">검색 실패: {String($mutation.error)}</Typography>
+    {:else if $mutation.data}
+      {#if $mutation.data.length === 0}
+        <Typography variant="body">일치하는 유저가 없습니다.</Typography>
+      {:else}
+        <Typography variant="body">{$mutation.data.length}건 검색됨</Typography>
+        <div class="cards">
+          {#each $mutation.data as user (user.id)}
+            <Paper class="userCard">
+              <Typography variant="body">id: {user.id}</Typography>
+              <Typography variant="body"
+                >email: {user.email ?? '-'} (verified: {user.isEmailVerified ?? false})</Typography
+              >
+              <Typography variant="body">nickname: {user.nickname}</Typography>
+              <Typography variant="body">localId: {user.localId ?? '-'}</Typography>
+              <Typography variant="body">active: {user.active}</Typography>
+              <Typography variant="body">isAdmin: {user.isAdmin}</Typography>
+              <Typography variant="body">가입일: {formatDate(user.regDate)}</Typography>
+              <Typography variant="body"
+                >최근 로그인: {formatDate(new Date(user.lastLoginTimestamp).toISOString())}</Typography
+              >
+              <Typography variant="body">
+                로그인 수단:
+                {#if user.authProviders.length === 0}
+                  (없음)
+                {:else}
+                  {user.authProviders.map((p) => AUTH_PROVIDER_LABEL[p]).join(', ')}
+                {/if}
+              </Typography>
+              <details>
+                <summary>소셜 계정 상세</summary>
+                <Typography variant="body">google: {user.socialAccounts.googleEmail ?? '-'}</Typography>
+                <Typography variant="body">kakao: {user.socialAccounts.kakaoEmail ?? '-'}</Typography>
+                <Typography variant="body">apple: {user.socialAccounts.appleEmail ?? '-'}</Typography>
+                <Typography variant="body">facebook name: {user.socialAccounts.facebookName ?? '-'}</Typography>
+              </details>
+            </Paper>
+          {/each}
+        </div>
+      {/if}
+    {:else}
+      <Typography variant="body"
+        >이메일을 입력해 유저를 검색하세요. (대소문자 정확히 일치해야 함, 비활성 유저 포함)</Typography
+      >
+    {/if}
+  </section>
+</div>
+
+<style>
+  div.wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  header.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  form > .search-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+  }
+
+  section.results {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  div.cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
+
+  :global(.userCard) {
+    min-width: 400px;
+    width: 45%;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  details > summary {
+    cursor: pointer;
+    margin-top: 8px;
+    font-size: 14px;
+    color: var(--color-text-default);
+  }
+</style>

--- a/apps/snutt-admin-web/src/entities/User.ts
+++ b/apps/snutt-admin-web/src/entities/User.ts
@@ -1,0 +1,28 @@
+export type AuthProvider = 'LOCAL' | 'FACEBOOK' | 'GOOGLE' | 'KAKAO' | 'APPLE';
+
+export const AUTH_PROVIDER_LABEL: Record<AuthProvider, string> = {
+  LOCAL: '아이디/비밀번호',
+  FACEBOOK: '페이스북',
+  GOOGLE: '구글',
+  KAKAO: '카카오',
+  APPLE: '애플',
+};
+
+export type AdminUserSearchResult = {
+  id: string;
+  email: string | null;
+  isEmailVerified: boolean | null;
+  nickname: string;
+  localId: string | null;
+  isAdmin: boolean;
+  active: boolean;
+  regDate: string;
+  lastLoginTimestamp: number;
+  authProviders: AuthProvider[];
+  socialAccounts: {
+    googleEmail: string | null;
+    kakaoEmail: string | null;
+    appleEmail: string | null;
+    facebookName: string | null;
+  };
+};

--- a/apps/snutt-admin-web/src/infrastructures/createDiaryRepository.ts
+++ b/apps/snutt-admin-web/src/infrastructures/createDiaryRepository.ts
@@ -1,6 +1,7 @@
 import type { SnuttBackend } from '@si/snutt-backend';
-import type { DiaryRepository } from '../repositories/DiaryRepository';
+
 import type { CreateDailyClassTypeRequest, CreateQuestionRequest } from '../entities/Diary';
+import type { DiaryRepository } from '../repositories/DiaryRepository';
 
 export const createDiaryRepository = ({ snuttBackend }: { snuttBackend: SnuttBackend }): DiaryRepository => {
   return {

--- a/apps/snutt-admin-web/src/infrastructures/createUserSiSnuttBackendRepository.ts
+++ b/apps/snutt-admin-web/src/infrastructures/createUserSiSnuttBackendRepository.ts
@@ -1,0 +1,14 @@
+import type { SnuttBackend } from '@si/snutt-backend';
+
+import type { UserRepository } from '../repositories/UserRepository';
+
+export const createUserSiSnuttBackendRepository = ({
+  snuttBackend,
+}: {
+  snuttBackend: SnuttBackend;
+}): UserRepository => {
+  return {
+    searchUsersByEmail: ({ email, token }) =>
+      snuttBackend.http.get['/v1/admin/users/search']({ query: { email }, token }),
+  };
+};

--- a/apps/snutt-admin-web/src/main.ts
+++ b/apps/snutt-admin-web/src/main.ts
@@ -6,19 +6,21 @@ import { serviceContextSetter } from './app/contexts/ServiceContext';
 import { createAdminPopupSiSnuttBackendRepository } from './infrastructures/createAdminPopupSiSnuttBackendRepository';
 import { createAuthSiSnuttBackendRepository } from './infrastructures/createAuthSiSnuttBackendRepository';
 import { createConfigSiSnuttBackendRepository } from './infrastructures/createConfigSiSnuttBackendRepository';
+import { createDiaryRepository } from './infrastructures/createDiaryRepository';
 import { createHtmlDocumentThemeRepository } from './infrastructures/createHtmlDocumentThemeRepository';
 import { createImportMetaEnvironmentRepository } from './infrastructures/createImportMetaEnvironmentRepository';
 import { createLocalStorageRepository } from './infrastructures/createLocalStorageRepository';
 import { createPopupImageFetchRepository } from './infrastructures/createPopupImageFetchRepository';
 import { createPushNotificationSiSnuttBackendRepository } from './infrastructures/createPushNotificationSiSnuttBackendRepository';
 import { createUserPopupSiSnuttBackendRepository } from './infrastructures/createUserPopupSiSnuttBackendRepository';
+import { createUserSiSnuttBackendRepository } from './infrastructures/createUserSiSnuttBackendRepository';
 import { createAuthService } from './services/AuthService';
 import { createConfigService } from './services/ConfigService';
+import { createDiaryService } from './services/DiaryService';
 import { createPopupService } from './services/PopupService';
 import { createPushNotificationService } from './services/PushNotificationService';
 import { createScreenService } from './services/ScreenService';
-import { createDiaryService } from './services/DiaryService';
-import { createDiaryRepository } from './infrastructures/createDiaryRepository';
+import { createUserService } from './services/UserService';
 
 const apiKey = import.meta.env.VITE_API_KEY;
 const environmentRepository = createImportMetaEnvironmentRepository();
@@ -62,6 +64,10 @@ const diaryService = createDiaryService({
   diaryRepository: createDiaryRepository({ snuttBackend }),
 });
 
+const userService = createUserService({
+  userRepository: createUserSiSnuttBackendRepository({ snuttBackend }),
+});
+
 document.documentElement.style.setProperty('transition', 'none');
 screenService.setCurrentTheme(screenService.getInitialTheme());
 setTimeout(() => {
@@ -79,6 +85,7 @@ const app = new App({
         screenService,
         popupService,
         diaryService,
+        userService,
       }),
     )
     .set(...environmentContextSetter({ APP_ENV: mode })),

--- a/apps/snutt-admin-web/src/repositories/UserRepository.ts
+++ b/apps/snutt-admin-web/src/repositories/UserRepository.ts
@@ -1,0 +1,5 @@
+import type { AdminUserSearchResult } from '../entities/User';
+
+export type UserRepository = {
+  searchUsersByEmail: (req: { email: string; token: string }) => Promise<AdminUserSearchResult[]>;
+};

--- a/apps/snutt-admin-web/src/services/UserService.ts
+++ b/apps/snutt-admin-web/src/services/UserService.ts
@@ -1,0 +1,12 @@
+import type { AdminUserSearchResult } from '../entities/User';
+import type { UserRepository } from '../repositories/UserRepository';
+
+export type UserService = {
+  searchUsersByEmail: (req: { email: string; token: string }) => Promise<AdminUserSearchResult[]>;
+};
+
+export const createUserService = ({ userRepository }: { userRepository: UserRepository }): UserService => {
+  return {
+    searchUsersByEmail: ({ email, token }) => userRepository.searchUsersByEmail({ email: email.trim(), token }),
+  };
+};

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -104,6 +104,32 @@ export const implSnuttBackend = ({ baseUrl, apiKey }: { baseUrl: string; apiKey:
               active: boolean;
             }[]
           >({ method: 'GET', path: '/v1/admin/diary/dailyClassTypes', token }),
+
+        '/v1/admin/users/search': ({ query, token }: { query: { email: string }; token: string }) =>
+          httpCall<
+            {
+              id: string;
+              email: string | null;
+              isEmailVerified: boolean | null;
+              nickname: string;
+              localId: string | null;
+              isAdmin: boolean;
+              active: boolean;
+              regDate: string;
+              lastLoginTimestamp: number;
+              authProviders: ('LOCAL' | 'FACEBOOK' | 'GOOGLE' | 'KAKAO' | 'APPLE')[];
+              socialAccounts: {
+                googleEmail: string | null;
+                kakaoEmail: string | null;
+                appleEmail: string | null;
+                facebookName: string | null;
+              };
+            }[]
+          >({
+            method: 'GET',
+            path: `/v1/admin/users/search?email=${encodeURIComponent(query.email)}`,
+            token,
+          }),
       },
 
       post: {


### PR DESCRIPTION
## What
snutt-admin-web에 "유저 검색" 탭을 추가했어요.
- 이메일 입력 → 매칭된 유저들을 카드로 표시
- 각 유저의 기본 정보와 어떤 로그인 수단(LOCAL/구글/카카오/애플/페이스북)으로 가입했는지 노출

snutt 백엔드 측 의존 PR: wafflestudio/snutt#516 (선반영 필요)

## Why
- 본인 로그인 방법을 까먹은 유저 문의 대응 용도예요. 그동안은 DB를 직접 뒤져야 했는데, 어드민 페이지에서 바로 확인할 수 있게 했어요.

## Test plan
- [ ] dev 환경에서 어드민 계정으로 로그인 후 "유저 검색" 탭 진입
- [ ] 본인 이메일 검색 시 카드에 본인 정보/로그인 수단 표시되는지 확인
- [ ] 없는 이메일 입력 시 "일치하는 유저가 없습니다" 표시
- [ ] 백엔드 API 미배포 상태에서는 검색 실패 메시지 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)